### PR TITLE
Fix bug on on methods with literals different than Symbol and GlobalVariable

### DIFF
--- a/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
@@ -17,7 +17,15 @@ RBGlobalVariableRuleTest >> methodNotUsesGlobal [
 
 { #category : #tests }
 RBGlobalVariableRuleTest >> methodNotUsesGlobal2 [
-	Object new 
+	| x y z a b c |
+	x := '...'.
+	y := 1.9 .
+	z := #(a b c).
+	a := { 1 . 2 . 3 }.
+	b := #a.
+	c := $a.
+	
+	^ x
 ]
 
 { #category : #tests }
@@ -31,6 +39,12 @@ RBGlobalVariableRuleTest >> methodUsesGlobal2 [
 ]
 
 { #category : #tests }
+RBGlobalVariableRuleTest >> testTheRuleCanCheckMethodsWithDifferentKindsOfLiterals [
+	self assert: (RBGlobalVariablesUsage new check: self class>>#methodNotUsesGlobal2)
+		isEmpty  
+]
+
+{ #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
 	self assert: self applyingCritiques size equals: 2
 ]
@@ -38,6 +52,6 @@ RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
 { #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleOnlyMethodUsesGlobal1And2 [
 	self
-		assert: (self applyingCritiques collect: #selector) asArray
-		equals: {#methodUsesGlobal . #methodUsesGlobal2}
+		assert: (self applyingCritiques collect: #selector) asSet
+		equals: {#methodUsesGlobal . #methodUsesGlobal2} asSet
 ]

--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -17,7 +17,13 @@ RBGlobalVariablesUsage class >> checksMethod [
 { #category : #running }
 RBGlobalVariablesUsage >> basicCheck: aMethod [
 	^ (aMethod literals
-		select: [ :l | l isSymbol not and: [ l isGlobalVariable ] ])
+		select: [ :l | 
+			l isSymbol not 
+				and: [ l isString not
+				and: [ l isNumber not
+				and: [ l isArray not
+				and: [ l isCharacter not
+				and: [ l isGlobalVariable ] ] ] ] ] ])
 		anySatisfy: [ :v | v value isClass not ]
 ]
 


### PR DESCRIPTION
Fix bug that happens when the method contains literals of another kind than symbol or globalVariable.
Test created for this case.